### PR TITLE
WIP: CoffeeNet starter with opinionated monitoring configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased]
-
+### Added
+- `coffeenet-starter-monitoring`
 
 ## [0.32.0]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - `coffeenet-starter-monitoring`
+- `coffeenet-actuator`
 
 ## [0.32.0]
 ### Added

--- a/coffeenet-actuator/pom.xml
+++ b/coffeenet-actuator/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <artifactId>coffeenet-starter-parent</artifactId>
         <groupId>coffee.synyx</groupId>
-        <version>0.30.0-SNAPSHOT</version>
+        <version>0.33.0-SNAPSHOT</version>
         <relativePath>../coffeenet-starter-parent/pom.xml</relativePath>
     </parent>
 
     <artifactId>coffeenet-actuator</artifactId>
-    <version>0.30.0-SNAPSHOT</version>
+    <version>0.33.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>CoffeeNet Actuator</name>
@@ -24,6 +24,24 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-actuator</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>coffee.synyx</groupId>
+            <artifactId>starter-security</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-validator</artifactId>
+        </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/coffeenet-actuator/pom.xml
+++ b/coffeenet-actuator/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>coffeenet-starter-parent</artifactId>
+        <groupId>coffee.synyx</groupId>
+        <version>0.30.0-SNAPSHOT</version>
+        <relativePath>../coffeenet-starter-parent/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>coffeenet-actuator</artifactId>
+    <version>0.30.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>CoffeeNet Actuator</name>
+    <description>
+        Implementation of CoffeeNet specific actuator features.
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-actuator</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/coffeenet-actuator/src/main/java/coffee/synyx/actuate/AuthServerHealthIndicator.java
+++ b/coffeenet-actuator/src/main/java/coffee/synyx/actuate/AuthServerHealthIndicator.java
@@ -1,0 +1,33 @@
+package coffee.synyx.actuate;
+
+import org.springframework.boot.actuate.health.AbstractHealthIndicator;
+import org.springframework.boot.actuate.health.Health;
+
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.client.UnknownHttpStatusCodeException;
+
+
+public class AuthServerHealthIndicator extends AbstractHealthIndicator {
+
+    private final RestTemplate restTemplate;
+    private final String checkUrl;
+
+    public AuthServerHealthIndicator(RestTemplate restTemplate, String checkUrl) {
+
+        this.restTemplate = restTemplate;
+        this.checkUrl = checkUrl;
+    }
+
+    @Override
+    protected void doHealthCheck(Health.Builder builder) {
+
+        try {
+            restTemplate.headForHeaders(checkUrl);
+            builder.up();
+        } catch (HttpServerErrorException | UnknownHttpStatusCodeException | ResourceAccessException e) {
+            builder.down(e);
+        }
+    }
+}

--- a/coffeenet-actuator/src/main/java/coffee/synyx/actuate/autoconfigure/AuthServerHealthIndicatorConfiguration.java
+++ b/coffeenet-actuator/src/main/java/coffee/synyx/actuate/autoconfigure/AuthServerHealthIndicatorConfiguration.java
@@ -1,0 +1,58 @@
+package coffee.synyx.actuate.autoconfigure;
+
+import coffee.synyx.actuate.AuthServerHealthIndicator;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.boot.autoconfigure.condition.AllNestedConditions;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Configuration;
+
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.oauth2.client.OAuth2ClientContext;
+import org.springframework.web.client.RestTemplate;
+
+import static coffee.synyx.autoconfigure.CoffeeNetConfigurationProperties.INTEGRATION;
+import static org.springframework.context.annotation.ConfigurationCondition.ConfigurationPhase.PARSE_CONFIGURATION;
+
+
+/**
+ * Health indicator for auth server in environments using CoffeeNet security.
+ */
+@Configuration
+@ConditionalOnClass({OAuth2ClientContext.class, WebSecurityConfigurerAdapter.class})
+@Conditional({AuthServerHealthIndicatorConfiguration.OnSecurityAndIntegrationEnabled.class})
+public class AuthServerHealthIndicatorConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean(name = "authServerHealthIndicator")
+    public HealthIndicator authServerHealthIndicator(
+            AuthServerHealthIndicatorConfigurationProperties authServerHealthIndicatorConfigurationProperties) {
+
+        return new AuthServerHealthIndicator(new RestTemplate(), authServerHealthIndicatorConfigurationProperties.getHealthUri());
+    }
+
+    @Bean
+    public AuthServerHealthIndicatorConfigurationProperties authServerHealthIndicatorConfigurationProperties() {
+
+        return new AuthServerHealthIndicatorConfigurationProperties();
+    }
+
+    static class OnSecurityAndIntegrationEnabled extends AllNestedConditions {
+
+        OnSecurityAndIntegrationEnabled() {
+            super(PARSE_CONFIGURATION);
+        }
+
+        @ConditionalOnProperty(prefix = "coffeenet.security", name = "enabled", havingValue = "true", matchIfMissing = true)
+        static class OnSecurityEnabled {
+        }
+
+        @ConditionalOnProperty(prefix = "coffeenet", name = "profile", havingValue = INTEGRATION)
+        static class OnIntegrationProfileEnabled {
+        }
+    }
+}

--- a/coffeenet-actuator/src/main/java/coffee/synyx/actuate/autoconfigure/AuthServerHealthIndicatorConfigurationProperties.java
+++ b/coffeenet-actuator/src/main/java/coffee/synyx/actuate/autoconfigure/AuthServerHealthIndicatorConfigurationProperties.java
@@ -1,0 +1,23 @@
+package coffee.synyx.actuate.autoconfigure;
+
+import org.hibernate.validator.constraints.NotBlank;
+import org.hibernate.validator.constraints.URL;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+@Validated
+@ConfigurationProperties("coffeenet.monitoring.security")
+public class AuthServerHealthIndicatorConfigurationProperties {
+
+    @URL(message = "Please provide a valid url to your oauth health endpoint")
+    @NotBlank(message = "Please provide the user endpoint of the oauth server usually ending with /health")
+    private String healthUri = "http://localhost:9999/health";
+
+    public String getHealthUri() {
+        return healthUri;
+    }
+
+    public void setHealthUri(String healthUri) {
+        this.healthUri = healthUri;
+    }
+}

--- a/coffeenet-actuator/src/main/resources/META-INF/spring.factories
+++ b/coffeenet-actuator/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+coffee.synyx.actuate.autoconfigure.AuthServerHealthIndicatorConfiguration

--- a/coffeenet-actuator/src/test/java/coffee/synyx/actuate/AuthServerHealthIndicatorTest.java
+++ b/coffeenet-actuator/src/test/java/coffee/synyx/actuate/AuthServerHealthIndicatorTest.java
@@ -1,0 +1,55 @@
+package coffee.synyx.actuate;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.Status;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.RestTemplate;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AuthServerHealthIndicatorTest {
+
+    private AuthServerHealthIndicator sut;
+
+    @Mock
+    private RestTemplate restTemplate;
+
+    @Before
+    public void setUp() {
+
+        sut = new AuthServerHealthIndicator(restTemplate, "url");
+    }
+
+    @Test
+    public void healthIsUp() {
+
+        when(restTemplate.headForHeaders("url")).thenReturn(new HttpHeaders());
+
+        Health.Builder builder = new Health.Builder();
+        sut.doHealthCheck(builder);
+
+        assertThat(builder.build().getStatus(), is(Status.UP));
+    }
+
+
+    @Test
+    public void healthIsDownWithServerError() {
+
+        when(restTemplate.headForHeaders("url")).thenThrow(new HttpServerErrorException(INTERNAL_SERVER_ERROR));
+
+        Health.Builder builder = new Health.Builder();
+        sut.doHealthCheck(builder);
+
+        assertThat(builder.build().getStatus(), is(Status.DOWN));
+    }
+}

--- a/coffeenet-actuator/src/test/java/coffee/synyx/actuate/autoconfigure/AuthServerHealthIndicatorConfigurationPropertiesTest.java
+++ b/coffeenet-actuator/src/test/java/coffee/synyx/actuate/autoconfigure/AuthServerHealthIndicatorConfigurationPropertiesTest.java
@@ -1,0 +1,16 @@
+package coffee.synyx.actuate.autoconfigure;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class AuthServerHealthIndicatorConfigurationPropertiesTest {
+
+    @Test
+    public void testDefaultValues() {
+
+        AuthServerHealthIndicatorConfigurationProperties sut = new AuthServerHealthIndicatorConfigurationProperties();
+        assertThat(sut.getHealthUri(), is("http://localhost:9999/health"));
+    }
+}

--- a/coffeenet-starter-monitoring/pom.xml
+++ b/coffeenet-starter-monitoring/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <artifactId>coffeenet-starter-parent</artifactId>
         <groupId>coffee.synyx</groupId>
-        <version>0.30.0-SNAPSHOT</version>
+        <version>0.33.0-SNAPSHOT</version>
         <relativePath>../coffeenet-starter-parent/pom.xml</relativePath>
     </parent>
 
     <artifactId>starter-monitoring</artifactId>
-    <version>0.30.0-SNAPSHOT</version>
+    <version>0.33.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>CoffeeNet Starter Monitoring</name>

--- a/coffeenet-starter-monitoring/pom.xml
+++ b/coffeenet-starter-monitoring/pom.xml
@@ -34,16 +34,6 @@
             <artifactId>coffeenet-actuator</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>io.micrometer</groupId>
-            <artifactId>micrometer-core</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>io.micrometer</groupId>
-            <artifactId>micrometer-spring-legacy</artifactId>
-        </dependency>
-
     </dependencies>
 
 </project>

--- a/coffeenet-starter-monitoring/pom.xml
+++ b/coffeenet-starter-monitoring/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>coffeenet-starter-parent</artifactId>
+        <groupId>coffee.synyx</groupId>
+        <version>0.30.0-SNAPSHOT</version>
+        <relativePath>../coffeenet-starter-parent/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>starter-monitoring</artifactId>
+    <version>0.30.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>CoffeeNet Starter Monitoring</name>
+    <description>
+        This starter is designed to provide the
+        CoffeeNet monitoring aspects (metrics &amp; health endpoints)
+    </description>
+
+    <dependencies>
+        <!-- CoffeeNet Autoconfigure -->
+        <dependency>
+            <groupId>coffee.synyx</groupId>
+            <artifactId>autoconfigure</artifactId>
+        </dependency>
+
+        <!-- Monitoring dependencies -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-spring-legacy</artifactId>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/coffeenet-starter-monitoring/pom.xml
+++ b/coffeenet-starter-monitoring/pom.xml
@@ -30,8 +30,8 @@
 
         <!-- Monitoring dependencies -->
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-actuator</artifactId>
+            <groupId>coffee.synyx</groupId>
+            <artifactId>coffeenet-actuator</artifactId>
         </dependency>
 
         <dependency>

--- a/coffeenet-starter-parent/pom.xml
+++ b/coffeenet-starter-parent/pom.xml
@@ -60,6 +60,12 @@
 
             <dependency>
                 <groupId>coffee.synyx</groupId>
+                <artifactId>coffeenet-actuator</artifactId>
+                <version>0.30.0-SNAPSHOT</version>
+            </dependency>
+
+            <dependency>
+                <groupId>coffee.synyx</groupId>
                 <artifactId>starter-security</artifactId>
                 <version>0.33.0-SNAPSHOT</version>
             </dependency>

--- a/coffeenet-starter-parent/pom.xml
+++ b/coffeenet-starter-parent/pom.xml
@@ -61,7 +61,7 @@
             <dependency>
                 <groupId>coffee.synyx</groupId>
                 <artifactId>coffeenet-actuator</artifactId>
-                <version>0.30.0-SNAPSHOT</version>
+                <version>0.33.0-SNAPSHOT</version>
             </dependency>
 
             <dependency>
@@ -85,7 +85,7 @@
             <dependency>
                 <groupId>coffee.synyx</groupId>
                 <artifactId>starter-monitoring</artifactId>
-                <version>0.30.0-SNAPSHOT</version>
+                <version>0.33.0-SNAPSHOT</version>
             </dependency>
 
             <dependency>

--- a/coffeenet-starter-parent/pom.xml
+++ b/coffeenet-starter-parent/pom.xml
@@ -45,7 +45,6 @@
         <dependency.check.report.dir>${project.build.directory}/dependency-check</dependency.check.report.dir>
         <sonar.dependencyCheck.reportPath>${dependency.check.report.dir}/dependency-check-report.xml
         </sonar.dependencyCheck.reportPath>
-        <micrometer.version>1.0.3</micrometer.version>
     </properties>
 
     <dependencyManagement>
@@ -117,19 +116,6 @@
                 <groupId>de.appelgriepsch.logback</groupId>
                 <artifactId>logback-gelf-appender</artifactId>
                 <version>${logback-gelf-appender.version}</version>
-            </dependency>
-
-            <!-- Remove once upgraded to Spring Boot 2.0+ -->
-            <dependency>
-                <groupId>io.micrometer</groupId>
-                <artifactId>micrometer-core</artifactId>
-                <version>${micrometer.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>io.micrometer</groupId>
-                <artifactId>micrometer-spring-legacy</artifactId>
-                <version>${micrometer.version}</version>
             </dependency>
 
             <!-- Spring Cloud -->

--- a/coffeenet-starter-parent/pom.xml
+++ b/coffeenet-starter-parent/pom.xml
@@ -45,6 +45,7 @@
         <dependency.check.report.dir>${project.build.directory}/dependency-check</dependency.check.report.dir>
         <sonar.dependencyCheck.reportPath>${dependency.check.report.dir}/dependency-check-report.xml
         </sonar.dependencyCheck.reportPath>
+        <micrometer.version>1.0.3</micrometer.version>
     </properties>
 
     <dependencyManagement>
@@ -77,6 +78,12 @@
 
             <dependency>
                 <groupId>coffee.synyx</groupId>
+                <artifactId>starter-monitoring</artifactId>
+                <version>0.30.0-SNAPSHOT</version>
+            </dependency>
+
+            <dependency>
+                <groupId>coffee.synyx</groupId>
                 <artifactId>starter-navigation</artifactId>
                 <version>0.33.0-SNAPSHOT</version>
             </dependency>
@@ -104,6 +111,19 @@
                 <groupId>de.appelgriepsch.logback</groupId>
                 <artifactId>logback-gelf-appender</artifactId>
                 <version>${logback-gelf-appender.version}</version>
+            </dependency>
+
+            <!-- Remove once upgraded to Spring Boot 2.0+ -->
+            <dependency>
+                <groupId>io.micrometer</groupId>
+                <artifactId>micrometer-core</artifactId>
+                <version>${micrometer.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.micrometer</groupId>
+                <artifactId>micrometer-spring-legacy</artifactId>
+                <version>${micrometer.version}</version>
             </dependency>
 
             <!-- Spring Cloud -->

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
         <module>coffeenet-starter-monitoring</module>
         <module>coffeenet-starter-security</module>
         <module>coffeenet-autoconfigure</module>
+        <module>coffeenet-actuator</module>
         <module>coffeenet-starter-parent</module>
     </modules>
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
         <module>coffeenet-starter-navigation</module>
         <module>coffeenet-starter-discovery</module>
         <module>coffeenet-starter-logging</module>
+        <module>coffeenet-starter-monitoring</module>
         <module>coffeenet-starter-security</module>
         <module>coffeenet-autoconfigure</module>
         <module>coffeenet-starter-parent</module>


### PR DESCRIPTION
We want some out-of-the-box monitoring helpers. This should include:

* Preparation for the new `micrometer` stack in Spring Boot 2.0
* Spring Boot Actuator health endpoints & checks for connectivity to CoffeeNet related functions
  * Reachability of discovery (Eureka)
  * Reachability of configuration server (some apps will start nevertheless and will "work" in a reduced-functionality-mode)
* Push metrics via `micrometer` registries 
