### PR TITLE
Add 'coffeenet.navigation.display-in-navigation-for-roles' property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- 'coffeenet.navigation.display-in-navigation-for-roles'
+   to display navigation element of an application in the navigation
+   for special roles and hide it for all others
+
+### Deprecated
+- 'coffeenet.allowed-authorities' in favor of 'coffeenet.navigation.display-in-navigation-for-roles'
 
 
 ## [0.37.0]

--- a/coffeenet-autoconfigure/src/main/java/coffee/synyx/autoconfigure/CoffeeNetConfigurationProperties.java
+++ b/coffeenet-autoconfigure/src/main/java/coffee/synyx/autoconfigure/CoffeeNetConfigurationProperties.java
@@ -37,6 +37,12 @@ public class CoffeeNetConfigurationProperties {
     )
     private String applicationName;
 
+    /**
+     * @deprecated since 0.38.0 in favor of
+     * {@link coffee.synyx.autoconfigure.navigation.CoffeeNetNavigationProperties}
+     * 'coffeenet.navigation.displayForRoles'
+     */
+    @Deprecated
     private String allowedAuthorities;
 
     public Profile getProfile() {
@@ -63,12 +69,13 @@ public class CoffeeNetConfigurationProperties {
     }
 
 
+    @Deprecated
     public String getAllowedAuthorities() {
 
         return allowedAuthorities;
     }
 
-
+    @Deprecated
     public void setAllowedAuthorities(String allowedAuthorities) {
 
         this.allowedAuthorities = allowedAuthorities;

--- a/coffeenet-autoconfigure/src/main/java/coffee/synyx/autoconfigure/discovery/config/CoffeeNetDiscoveryAutoConfiguration.java
+++ b/coffeenet-autoconfigure/src/main/java/coffee/synyx/autoconfigure/discovery/config/CoffeeNetDiscoveryAutoConfiguration.java
@@ -151,12 +151,6 @@ public class CoffeeNetDiscoveryAutoConfiguration {
                     new URL(base, StringUtils.trimLeadingCharacter(instance.getHealthCheckUrlPath(), '/')).toString());
             }
 
-            String allowedAuthorities = coffeeNetConfigurationProperties.getAllowedAuthorities();
-
-            if (allowedAuthorities != null) {
-                instance.getMetadataMap().put("allowedAuthorities", allowedAuthorities);
-            }
-
             return instance;
         }
 

--- a/coffeenet-autoconfigure/src/main/java/coffee/synyx/autoconfigure/navigation/CoffeeNetNavigationProperties.java
+++ b/coffeenet-autoconfigure/src/main/java/coffee/synyx/autoconfigure/navigation/CoffeeNetNavigationProperties.java
@@ -28,6 +28,17 @@ public class CoffeeNetNavigationProperties {
     @NotNull(message = "Please provide the information to show or not show the version number in the navigation")
     private boolean displayVersions = true;
 
+    /**
+     * Comma separated list of roles that are allowed to see
+     * this application in the navigation e.g.
+     *
+     * <pre>
+     * coffeenet.navigation:
+     *  display-in-navigation-for-roles: ROLE_COFFEENET-ADMIN, ROLE_USER
+     * </pre>
+     */
+    private String displayInNavigationForRoles;
+
     public String getProfileServiceName() {
 
         return profileServiceName;
@@ -63,13 +74,21 @@ public class CoffeeNetNavigationProperties {
         this.displayVersions = displayVersions;
     }
 
+    public String getDisplayInNavigationForRoles() {
+        return displayInNavigationForRoles;
+    }
+
+    public void setDisplayInNavigationForRoles(String displayInNavigationForRoles) {
+        this.displayInNavigationForRoles = displayInNavigationForRoles;
+    }
 
     @Override
     public String toString() {
-
-        return "CoffeeNetNavigationProperties{"
-            + "profileServiceName='" + profileServiceName + '\''
-            + ", logoutPath='" + logoutPath + '\''
-            + ", displayVersions=" + displayVersions + '}';
+        return "CoffeeNetNavigationProperties{" +
+                "profileServiceName='" + profileServiceName + '\'' +
+                ", logoutPath='" + logoutPath + '\'' +
+                ", displayVersions=" + displayVersions +
+                ", displayInNavigationForRoles='" + displayInNavigationForRoles + '\'' +
+                '}';
     }
 }

--- a/coffeenet-autoconfigure/src/test/java/coffee/synyx/autoconfigure/navigation/CoffeeNetNavigationPropertiesTest.java
+++ b/coffeenet-autoconfigure/src/test/java/coffee/synyx/autoconfigure/navigation/CoffeeNetNavigationPropertiesTest.java
@@ -4,6 +4,7 @@ import org.junit.Test;
 
 import static org.hamcrest.Matchers.is;
 
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 
 
@@ -19,5 +20,7 @@ public class CoffeeNetNavigationPropertiesTest {
 
         assertThat(sut.getLogoutPath(), is("/logout"));
         assertThat(sut.getProfileServiceName(), is("profile"));
+        assertThat(sut.getDisplayInNavigationForRoles(), is(nullValue()));
+        assertThat(sut.isDisplayVersions(), is(true));
     }
 }

--- a/coffeenet-starter-navigation-javascript/README.md
+++ b/coffeenet-starter-navigation-javascript/README.md
@@ -63,3 +63,7 @@ Just add the html snipped listed below:
 </body>
 </html>
 ```
+
+## Configuration
+
+see the navigation configuration in the [starter navigation readme](./../coffeenet-starter-navigation/README.md)

--- a/coffeenet-starter-navigation-thymeleaf/README.md
+++ b/coffeenet-starter-navigation-thymeleaf/README.md
@@ -69,3 +69,7 @@ All you have to do is to provide your information into the elements.
 </body>
 </html>
 ```
+
+## Configuration
+
+see the navigation configuration in the [starter navigation readme](./../coffeenet-starter-navigation/README.md)

--- a/coffeenet-starter-navigation/README.md
+++ b/coffeenet-starter-navigation/README.md
@@ -4,3 +4,14 @@ This is the base starter for the navigation starters like `starter-navigation-th
 This starter should not used directly in your application.
 
 Use the specific navigation starters with dedicated rendering engine you need for your project.
+
+## Configuration
+
+```yaml
+coffeenet:
+  navigation:
+    display-versions: true
+    display-in-navigation-for-roles:
+    logout-path: '/logout'
+    profile-service-name: 'profile'
+```


### PR DESCRIPTION
to display navigation element of an application in the navigation
for special roles and hide it for all others

'coffeenet.allowed-authorities' in favor of
'coffeenet.navigation.display-in-navigation-for-roles'