### PR TITLE
Use OpenJDK for Travis-CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 language: java
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 cache:
   directories:


### PR DESCRIPTION
Since Oracle JDK has now become a commercial offering and OpenJDK is the
future of opensource Java, CoffeeNet should build against OpenJDK
instead of the Oracle version.

Also it seems, that Travis builds with Oracle JDK 8 are failing
currently.