### PR TITLE
Migrate from Travis CI to GitHub Actions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - development
   pull_request:
 
 jobs:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,17 @@
+name: CoffeeNet Maven Build
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Build and verify with Maven
+      run: mvn -B clean verify --file pom.xml

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -24,4 +24,15 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-maven-
     - name: Build and verify with Maven
-      run: ./mvnw --batch-mode clean verify --file pom.xml
+      run: >
+        ./mvnw --batch-mode
+        -Pcoverage
+        clean verify
+        sonar:sonar
+        -Dsonar.host.url=https://sonarcloud.io
+        -Dsonar.organization=coffeenet
+        -Dsonar.projectKey=rocks.coffeenet:coffeenet-starter
+        -Dsonar.coverage.jacoco.xmlReportPaths=*/target/site/jacoco/jacoco.xml,*/target/site/jacoco-it/jacoco.xml
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -17,5 +17,11 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
+    - uses: actions/cache@v1
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
     - name: Build and verify with Maven
       run: ./mvnw --batch-mode clean verify --file pom.xml

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,6 +1,10 @@
 name: CoffeeNet Maven Build
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -18,4 +18,4 @@ jobs:
       with:
         java-version: 1.8
     - name: Build and verify with Maven
-      run: mvn -B clean verify --file pom.xml
+      run: ./mvnw -B clean verify --file pom.xml

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -18,4 +18,4 @@ jobs:
       with:
         java-version: 1.8
     - name: Build and verify with Maven
-      run: ./mvnw -B clean verify --file pom.xml
+      run: ./mvnw --batch-mode clean verify --file pom.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,13 +15,7 @@ before_install:
 git:
   depth: false
 
-addons:
-  sonarcloud:
-    organization: "coffeenet"
-    token:
-      secure: "tk6Cm1enKzy8Ob9RHHfy/7lfBwDB63dTkNJY8GrU5TWrt9hY2y6sCib1Jw+6Yv6zWKr52NyjfHv4tYYteIAR37DBi8uCvwE27Iu+PAGRLG5JBLVOmCsdZ7igw/GcorphvicB4pAOZ8DBPULlFBoELzqzXmdHOErzBE8v0iI8s7Wxj+D/zLljMe4vQmBD5GE0KY+m/x5CPHOlVHQvr6Q9sP8R15S1z+ipQyw4XIDvoZfopS83oicqucaMOcjBeYNHWZRL1T2rbZCXGi7JeQT85NdXwXkvDV4h+KO6MThNnl3l+Zy4mCc/a4KBg/ovaXFebFz5rEFidVFSyO178UoH57vPwR+e81TzC3zqkFy9v2l7I3eqJ7gwRVW2Zq6pbnBspWq3D2riLJzINs4O+aQqbn8PDxilRYVNivA/nhDhzgfY4Ub4BgCNXHGTQN6vy4PmaSLJmOz9FQxcyKQJIv1duin/ISJRUtc7A8eJhv+FKNhi2/nFLOPklqU+fVNBvEkqI5mRyEziNV5ZRkqlgkqXhlnNFI5GZaeXm68o9s1diEhO4/w2k+tcgfCC00TDOzcQdIooi48asH+eHRfmSC6K8/CUmJ3AeB620j0Ek7fRx0vacQg4fyVwUvkY6p6ORflcQr189g7J9LZY8g4rn1S0Vnbmo6CWqH127ROK+Q5h94o="
-
-script: ./mvnw $MAVEN_CLI_OPTS clean org.jacoco:jacoco-maven-plugin:prepare-agent verify sonar:sonar
+script: ./mvnw $MAVEN_CLI_OPTS clean verify
 
 before_deploy:
   - export RELEASE_NOTES=$(awk -v start=1 '/^#{2}[[:space:]].*$/{n++;next};n==start;n==start+1{exit}' CHANGELOG.md | markdown | awk '{printf "%s",$0} END {print ""}')

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-[![Build Status](https://travis-ci.org/coffeenet/coffeenet-starter.svg?branch=master)](https://travis-ci.org/coffeenet/coffeenet-starter)
-[![Latest coffeenet-starter on Maven Central](https://maven-badges.herokuapp.com/maven-central/rocks.coffeenet/coffeenet-starter/badge.svg?style=flat)](https://search.maven.org/search?q=g:rocks.coffeenet%20AND%20a:coffeenet-starter&core=gav)
+![CoffeeNet Maven Build](https://github.com/coffeenet/coffeenet-starter/workflows/CoffeeNet%20Maven%20Build/badge.svg) [![Latest coffeenet-starter on Maven Central](https://maven-badges.herokuapp.com/maven-central/rocks.coffeenet/coffeenet-starter/badge.svg?style=flat)](https://search.maven.org/search?q=g:rocks.coffeenet%20AND%20a:coffeenet-starter&core=gav)
 [![Sonarcloud Status](https://sonarcloud.io/api/project_badges/measure?project=rocks.coffeenet:coffeenet-starter&metric=coverage)](https://sonarcloud.io/dashboard?id=rocks.coffeenet:coffeenet-starter)
 
 # CoffeeNet Starters

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![CoffeeNet Maven Build](https://github.com/coffeenet/coffeenet-starter/workflows/CoffeeNet%20Maven%20Build/badge.svg) [![Latest coffeenet-starter on Maven Central](https://maven-badges.herokuapp.com/maven-central/rocks.coffeenet/coffeenet-starter/badge.svg?style=flat)](https://search.maven.org/search?q=g:rocks.coffeenet%20AND%20a:coffeenet-starter&core=gav)
+[![CoffeeNet Maven Build](https://github.com/coffeenet/coffeenet-starter/workflows/CoffeeNet%20Maven%20Build/badge.svg)](https://sonarcloud.io/organizations/coffeenet/projects) [![Latest coffeenet-starter on Maven Central](https://maven-badges.herokuapp.com/maven-central/rocks.coffeenet/coffeenet-starter/badge.svg?style=flat)](https://search.maven.org/search?q=g:rocks.coffeenet%20AND%20a:coffeenet-starter&core=gav)
 [![Sonarcloud Status](https://sonarcloud.io/api/project_badges/measure?project=rocks.coffeenet:coffeenet-starter&metric=coverage)](https://sonarcloud.io/dashboard?id=rocks.coffeenet:coffeenet-starter)
 
 # CoffeeNet Starters

--- a/coffeenet-parent/pom.xml
+++ b/coffeenet-parent/pom.xml
@@ -122,5 +122,54 @@
                 </plugins>
             </build>
         </profile>
+
+        <profile>
+            <id>coverage</id>
+            <build>
+                <plugins>
+
+                    <!-- Coverage -->
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <version>0.8.5</version>
+                        <executions>
+                            <execution>
+                                <id>default-prepare-agent</id>
+                                <goals>
+                                    <goal>prepare-agent</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>default-prepare-agent-integration</id>
+                                <goals>
+                                    <goal>prepare-agent-integration</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>default-report</id>
+                                <goals>
+                                    <goal>report</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>default-report-integration</id>
+                                <goals>
+                                    <goal>report-integration</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <!-- sonar -->
+                    <plugin>
+                        <groupId>org.sonarsource.scanner.maven</groupId>
+                        <artifactId>sonar-maven-plugin</artifactId>
+                        <version>3.7.0.1746</version>
+                    </plugin>
+
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>


### PR DESCRIPTION
With the availability of GitHub Actions, the 3rd party build integration with Travis CI becomes obsolete. GitHub Actions can be better integrated into the GitHub PR lifecycle.

TODOS:
* [x] Migrate the SonarCloud integration from Travis CI
* [ ] Migrate the release pipeline from Travis CI (removed)