### PR TITLE
Enable support for WebFlux in CoffeeNet instrumentation

### DIFF
--- a/coffeenet-autoconfigure/build.gradle
+++ b/coffeenet-autoconfigure/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     optionalImplementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     optionalImplementation 'org.springframework.boot:spring-boot-starter-security'
     optionalImplementation 'org.springframework.boot:spring-boot-starter-web'
+    optionalImplementation 'org.springframework.boot:spring-boot-starter-webflux'
 
     optionalImplementation 'javax.servlet:javax.servlet-api'
 

--- a/coffeenet-autoconfigure/src/main/java/rocks/coffeenet/autoconfigure/security/CoffeeNetProfileAutoConfiguration.java
+++ b/coffeenet-autoconfigure/src/main/java/rocks/coffeenet/autoconfigure/security/CoffeeNetProfileAutoConfiguration.java
@@ -1,8 +1,9 @@
-package rocks.coffeenet.autoconfigure.security.servlet;
+package rocks.coffeenet.autoconfigure.security;
 
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
@@ -12,10 +13,13 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
 
+import org.springframework.security.authentication.DefaultAuthenticationEventPublisher;
 import org.springframework.security.web.context.AbstractSecurityWebApplicationInitializer;
 
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import rocks.coffeenet.autoconfigure.security.servlet.CoffeeNetProfileArgumentResolver;
 
 import rocks.coffeenet.platform.domain.profile.CoffeeNetProfile;
 import rocks.coffeenet.platform.domain.profile.DelegatingPrincipalCoffeeNetProfileMapper;
@@ -31,9 +35,8 @@ import java.util.List;
  * @since  2.0.0
  */
 @Configuration(proxyBeanMethods = false)
-@AutoConfigureAfter(SecurityAutoConfiguration.class)
-@ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
-@ConditionalOnBean(name = AbstractSecurityWebApplicationInitializer.DEFAULT_FILTER_NAME)
+@AutoConfigureAfter({ SecurityAutoConfiguration.class })
+@ConditionalOnClass(DefaultAuthenticationEventPublisher.class)
 @Import(FallbackProfileMapperConfiguration.class)
 public class CoffeeNetProfileAutoConfiguration {
 
@@ -48,7 +51,11 @@ public class CoffeeNetProfileAutoConfiguration {
     }
 
     @Configuration(proxyBeanMethods = false)
-    @ConditionalOnBean(PrincipalCoffeeNetProfileMapper.class)
+    @ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
+    @ConditionalOnBean(
+        value = { PrincipalCoffeeNetProfileMapper.class },
+        name = AbstractSecurityWebApplicationInitializer.DEFAULT_FILTER_NAME
+    )
     static class CoffeeNetProfileArgumentResolverConfigurer implements WebMvcConfigurer {
 
         private final PrincipalCoffeeNetProfileMapper mapper;

--- a/coffeenet-autoconfigure/src/main/java/rocks/coffeenet/autoconfigure/security/CoffeeNetProfileAutoConfiguration.java
+++ b/coffeenet-autoconfigure/src/main/java/rocks/coffeenet/autoconfigure/security/CoffeeNetProfileAutoConfiguration.java
@@ -6,6 +6,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.boot.autoconfigure.security.reactive.ReactiveSecurityAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 
 import org.springframework.context.annotation.Bean;
@@ -19,6 +20,7 @@ import org.springframework.security.web.context.AbstractSecurityWebApplicationIn
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import rocks.coffeenet.autoconfigure.security.reactive.ReactiveCoffeeNetProfileArgumentResolver;
 import rocks.coffeenet.autoconfigure.security.servlet.CoffeeNetProfileArgumentResolver;
 
 import rocks.coffeenet.platform.domain.profile.CoffeeNetProfile;
@@ -35,7 +37,7 @@ import java.util.List;
  * @since  2.0.0
  */
 @Configuration(proxyBeanMethods = false)
-@AutoConfigureAfter({ SecurityAutoConfiguration.class })
+@AutoConfigureAfter({ SecurityAutoConfiguration.class, ReactiveSecurityAutoConfiguration.class })
 @ConditionalOnClass(DefaultAuthenticationEventPublisher.class)
 @Import(FallbackProfileMapperConfiguration.class)
 public class CoffeeNetProfileAutoConfiguration {
@@ -70,6 +72,20 @@ public class CoffeeNetProfileAutoConfiguration {
 
             CoffeeNetProfileArgumentResolver resolver = new CoffeeNetProfileArgumentResolver(mapper);
             resolvers.add(0, resolver);
+        }
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.REACTIVE)
+    @ConditionalOnBean(PrincipalCoffeeNetProfileMapper.class)
+    static class ReactiveCoffeeNetProfileArgumentResolverConfiguration {
+
+        @Bean
+        @ConditionalOnMissingBean(ReactiveCoffeeNetProfileArgumentResolver.class)
+        public ReactiveCoffeeNetProfileArgumentResolver reactiveCoffeeNetProfileArgumentResolver(
+            PrincipalCoffeeNetProfileMapper mapper) {
+
+            return new ReactiveCoffeeNetProfileArgumentResolver(mapper);
         }
     }
 }

--- a/coffeenet-autoconfigure/src/main/java/rocks/coffeenet/autoconfigure/security/CoffeeNetSecurityAutoConfiguration.java
+++ b/coffeenet-autoconfigure/src/main/java/rocks/coffeenet/autoconfigure/security/CoffeeNetSecurityAutoConfiguration.java
@@ -1,4 +1,4 @@
-package rocks.coffeenet.autoconfigure.security.servlet;
+package rocks.coffeenet.autoconfigure.security;
 
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;

--- a/coffeenet-autoconfigure/src/main/java/rocks/coffeenet/autoconfigure/security/FallbackProfileMapperConfiguration.java
+++ b/coffeenet-autoconfigure/src/main/java/rocks/coffeenet/autoconfigure/security/FallbackProfileMapperConfiguration.java
@@ -1,11 +1,9 @@
-package rocks.coffeenet.autoconfigure.security.servlet;
+package rocks.coffeenet.autoconfigure.security;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
-import rocks.coffeenet.autoconfigure.security.DefaultPrincipalCoffeeNetProfileMapper;
 
 import rocks.coffeenet.platform.domain.profile.PrincipalCoffeeNetProfileMapper;
 

--- a/coffeenet-autoconfigure/src/main/java/rocks/coffeenet/autoconfigure/security/oauth2/reactive/ReactiveOAuth2SecurityAutoConfiguration.java
+++ b/coffeenet-autoconfigure/src/main/java/rocks/coffeenet/autoconfigure/security/oauth2/reactive/ReactiveOAuth2SecurityAutoConfiguration.java
@@ -1,0 +1,40 @@
+package rocks.coffeenet.autoconfigure.security.oauth2.reactive;
+
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.boot.autoconfigure.security.oauth2.client.ClientsConfiguredCondition;
+import org.springframework.boot.autoconfigure.security.reactive.ReactiveSecurityAutoConfiguration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Configuration;
+
+import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+
+import reactor.core.publisher.Flux;
+
+
+/**
+ * {@link EnableAutoConfiguration Auto-configuration} for Spring Security OAuth2 in CoffeeNet applications.
+ *
+ * @author  Florian 'punycode' Krupicka - zh@punyco.de
+ * @since  2.0.0
+ */
+@Configuration(proxyBeanMethods = false)
+@AutoConfigureBefore(ReactiveSecurityAutoConfiguration.class)
+@ConditionalOnClass({ Flux.class, EnableWebFluxSecurity.class, ClientRegistration.class })
+@ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.REACTIVE)
+@Conditional(ClientsConfiguredCondition.class)
+public class ReactiveOAuth2SecurityAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean(ReactiveOAuth2SecurityCustomizer.class)
+    public ReactiveOAuth2SecurityCustomizer coffeeNetReactiveOAuth2SecurityCustomizer() {
+
+        return new ReactiveOAuth2SecurityCustomizer();
+    }
+}

--- a/coffeenet-autoconfigure/src/main/java/rocks/coffeenet/autoconfigure/security/oauth2/reactive/ReactiveOAuth2SecurityCustomizer.java
+++ b/coffeenet-autoconfigure/src/main/java/rocks/coffeenet/autoconfigure/security/oauth2/reactive/ReactiveOAuth2SecurityCustomizer.java
@@ -1,0 +1,25 @@
+package rocks.coffeenet.autoconfigure.security.oauth2.reactive;
+
+import org.springframework.boot.autoconfigure.security.oauth2.client.ClientsConfiguredCondition;
+
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+
+import rocks.coffeenet.autoconfigure.security.reactive.ReactiveServerHttpSecurityCustomizer;
+
+
+/**
+ * Enables OAuth2/OIDC for all {@link ServerHttpSecurity} instances. Automatically applied, when
+ * {@link ClientsConfiguredCondition} is matching.
+ *
+ * @author  Florian 'punycode' Krupicka - zh@punyco.de
+ */
+public class ReactiveOAuth2SecurityCustomizer implements ReactiveServerHttpSecurityCustomizer {
+
+    @Override
+    public void customize(ServerHttpSecurity http) {
+
+        http.oauth2Client()
+            .and()
+            .oauth2Login();
+    }
+}

--- a/coffeenet-autoconfigure/src/main/java/rocks/coffeenet/autoconfigure/security/reactive/ReactiveCoffeeNetProfileArgumentResolver.java
+++ b/coffeenet-autoconfigure/src/main/java/rocks/coffeenet/autoconfigure/security/reactive/ReactiveCoffeeNetProfileArgumentResolver.java
@@ -1,0 +1,42 @@
+package rocks.coffeenet.autoconfigure.security.reactive;
+
+import org.springframework.core.MethodParameter;
+
+import org.springframework.web.reactive.BindingContext;
+import org.springframework.web.reactive.result.method.HandlerMethodArgumentResolver;
+import org.springframework.web.server.ServerWebExchange;
+
+import reactor.core.publisher.Mono;
+
+import rocks.coffeenet.platform.domain.profile.CoffeeNetProfile;
+import rocks.coffeenet.platform.domain.profile.PrincipalCoffeeNetProfileMapper;
+
+
+/**
+ * @author  Florian 'punycode' Krupicka - zh@punyco.de
+ */
+public class ReactiveCoffeeNetProfileArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final PrincipalCoffeeNetProfileMapper profileMapper;
+
+    public ReactiveCoffeeNetProfileArgumentResolver(PrincipalCoffeeNetProfileMapper profileMapper) {
+
+        this.profileMapper = profileMapper;
+    }
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+
+        return CoffeeNetProfile.class.equals(parameter.getParameterType());
+    }
+
+
+    @Override
+    public Mono<Object> resolveArgument(MethodParameter parameter, BindingContext bindingContext,
+        ServerWebExchange exchange) {
+
+        return exchange.getPrincipal()
+            .filter((p) -> profileMapper.supports(p.getClass()))
+            .map(profileMapper::map);
+    }
+}

--- a/coffeenet-autoconfigure/src/main/java/rocks/coffeenet/autoconfigure/security/reactive/ReactiveCoffeeNetSecurityAutoConfiguration.java
+++ b/coffeenet-autoconfigure/src/main/java/rocks/coffeenet/autoconfigure/security/reactive/ReactiveCoffeeNetSecurityAutoConfiguration.java
@@ -1,0 +1,40 @@
+package rocks.coffeenet.autoconfigure.security.reactive;
+
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.security.reactive.ReactiveSecurityAutoConfiguration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
+import org.springframework.security.web.server.WebFilterChainProxy;
+
+import org.springframework.web.reactive.config.WebFluxConfigurer;
+
+import reactor.core.publisher.Flux;
+
+import java.util.List;
+
+
+/**
+ * {@link EnableAutoConfiguration Auto-configuration} for Spring Security in reactive CoffeeNet applications.
+ *
+ * @author  Florian 'punycode' Krupicka - zh@punyco.de
+ * @since  2.0.0
+ */
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnClass({ Flux.class, EnableWebFluxSecurity.class, WebFilterChainProxy.class, WebFluxConfigurer.class })
+@AutoConfigureBefore(ReactiveSecurityAutoConfiguration.class)
+public class ReactiveCoffeeNetSecurityAutoConfiguration {
+
+    @Bean
+    @ConditionalOnBean(ReactiveServerHttpSecurityCustomizer.class)
+    public ReactiveServerHttpSecurityPostProcessor coffeeNetReactiveSecurityPostProcessor(
+        List<ReactiveServerHttpSecurityCustomizer> customizers) {
+
+        return new ReactiveServerHttpSecurityPostProcessor(customizers);
+    }
+}

--- a/coffeenet-autoconfigure/src/main/java/rocks/coffeenet/autoconfigure/security/reactive/ReactiveServerHttpSecurityCustomizer.java
+++ b/coffeenet-autoconfigure/src/main/java/rocks/coffeenet/autoconfigure/security/reactive/ReactiveServerHttpSecurityCustomizer.java
@@ -1,0 +1,18 @@
+package rocks.coffeenet.autoconfigure.security.reactive;
+
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+
+
+/**
+ * A functional interface to customize {@link ServerHttpSecurity} instances. Instances of this interface will be
+ * automatically applied by {@link ReactiveServerHttpSecurityPostProcessor}. They are used in the CoffeeNet application
+ * platform, to enable security features in auto-configuration.
+ *
+ * @author  Florian 'punycode' Krupicka - zh@punyco.de
+ * @since  2.0.0
+ */
+@FunctionalInterface
+public interface ReactiveServerHttpSecurityCustomizer {
+
+    void customize(ServerHttpSecurity http);
+}

--- a/coffeenet-autoconfigure/src/main/java/rocks/coffeenet/autoconfigure/security/reactive/ReactiveServerHttpSecurityPostProcessor.java
+++ b/coffeenet-autoconfigure/src/main/java/rocks/coffeenet/autoconfigure/security/reactive/ReactiveServerHttpSecurityPostProcessor.java
@@ -1,6 +1,5 @@
 package rocks.coffeenet.autoconfigure.security.reactive;
 
-import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 
 import org.springframework.security.config.web.server.ServerHttpSecurity;
@@ -35,7 +34,7 @@ public class ReactiveServerHttpSecurityPostProcessor implements BeanPostProcesso
     }
 
     @Override
-    public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+    public Object postProcessAfterInitialization(Object bean, String beanName) {
 
         if (bean instanceof ServerHttpSecurity) {
             ServerHttpSecurity http = (ServerHttpSecurity) bean;

--- a/coffeenet-autoconfigure/src/main/java/rocks/coffeenet/autoconfigure/security/reactive/ReactiveServerHttpSecurityPostProcessor.java
+++ b/coffeenet-autoconfigure/src/main/java/rocks/coffeenet/autoconfigure/security/reactive/ReactiveServerHttpSecurityPostProcessor.java
@@ -1,0 +1,55 @@
+package rocks.coffeenet.autoconfigure.security.reactive;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
+
+/**
+ * Load {@link ReactiveServerHttpSecurityCustomizer} instances registered in the application context and apply them to
+ * {@link ServerHttpSecurity} instances.
+ *
+ * @author  Florian 'punycode' Krupicka - zh@punyco.de
+ * @since  2.0.0
+ */
+public class ReactiveServerHttpSecurityPostProcessor implements BeanPostProcessor {
+
+    private final List<ReactiveServerHttpSecurityCustomizer> customizers;
+
+    public ReactiveServerHttpSecurityPostProcessor(List<ReactiveServerHttpSecurityCustomizer> customizers) {
+
+        if (customizers == null) {
+            throw new IllegalArgumentException("list of customizers must not be null.");
+        }
+
+        if (customizers.isEmpty()) {
+            throw new IllegalArgumentException("list of customizers must not be empty.");
+        }
+
+        this.customizers = Collections.unmodifiableList(new LinkedList<>(customizers));
+    }
+
+    @Override
+    public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+
+        if (bean instanceof ServerHttpSecurity) {
+            ServerHttpSecurity http = (ServerHttpSecurity) bean;
+            customize(http);
+        }
+
+        return bean;
+    }
+
+
+    private void customize(ServerHttpSecurity http) {
+
+        for (ReactiveServerHttpSecurityCustomizer customizer : customizers) {
+            customizer.customize(http);
+        }
+    }
+}

--- a/coffeenet-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/coffeenet-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -2,7 +2,9 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 rocks.coffeenet.autoconfigure.security.CoffeeNetProfileAutoConfiguration,\
 rocks.coffeenet.autoconfigure.security.CoffeeNetSecurityAutoConfiguration,\
-rocks.coffeenet.autoconfigure.security.oauth2.servlet.OAuth2SecurityAutoConfiguration
+rocks.coffeenet.autoconfigure.security.oauth2.reactive.ReactiveOAuth2SecurityAutoConfiguration,\
+rocks.coffeenet.autoconfigure.security.oauth2.servlet.OAuth2SecurityAutoConfiguration,\
+rocks.coffeenet.autoconfigure.security.reactive.ReactiveCoffeeNetSecurityAutoConfiguration
 
 # Injected security configurers
 org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer=\

--- a/coffeenet-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/coffeenet-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -1,8 +1,8 @@
 # Auto-configuration
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-rocks.coffeenet.autoconfigure.security.oauth2.servlet.OAuth2SecurityAutoConfiguration,\
-rocks.coffeenet.autoconfigure.security.servlet.CoffeeNetProfileAutoConfiguration,\
-rocks.coffeenet.autoconfigure.security.servlet.CoffeeNetSecurityAutoConfiguration
+rocks.coffeenet.autoconfigure.security.CoffeeNetProfileAutoConfiguration,\
+rocks.coffeenet.autoconfigure.security.CoffeeNetSecurityAutoConfiguration,\
+rocks.coffeenet.autoconfigure.security.oauth2.servlet.OAuth2SecurityAutoConfiguration
 
 # Injected security configurers
 org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer=\

--- a/coffeenet-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/coffeenet-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -1,8 +1,8 @@
 # Auto-configuration
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-rocks.coffeenet.autoconfigure.security.servlet.CoffeeNetSecurityAutoConfiguration,\
+rocks.coffeenet.autoconfigure.security.oauth2.servlet.OAuth2SecurityAutoConfiguration,\
 rocks.coffeenet.autoconfigure.security.servlet.CoffeeNetProfileAutoConfiguration,\
-rocks.coffeenet.autoconfigure.security.oauth2.servlet.OAuth2SecurityAutoConfiguration
+rocks.coffeenet.autoconfigure.security.servlet.CoffeeNetSecurityAutoConfiguration
 
 # Injected security configurers
 org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer=\

--- a/coffeenet-autoconfigure/src/test/java/rocks/coffeenet/autoconfigure/security/CoffeeNetProfileAutoConfigurationTests.java
+++ b/coffeenet-autoconfigure/src/test/java/rocks/coffeenet/autoconfigure/security/CoffeeNetProfileAutoConfigurationTests.java
@@ -1,4 +1,4 @@
-package rocks.coffeenet.autoconfigure.security.servlet;
+package rocks.coffeenet.autoconfigure.security;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -7,8 +7,7 @@ import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
 
-import rocks.coffeenet.autoconfigure.security.DefaultPrincipalCoffeeNetProfileMapper;
-import rocks.coffeenet.autoconfigure.security.servlet.CoffeeNetProfileAutoConfiguration.CoffeeNetProfileArgumentResolverConfigurer;
+import rocks.coffeenet.autoconfigure.security.CoffeeNetProfileAutoConfiguration.CoffeeNetProfileArgumentResolverConfigurer;
 
 import rocks.coffeenet.platform.domain.profile.DelegatingPrincipalCoffeeNetProfileMapper;
 

--- a/coffeenet-autoconfigure/src/test/java/rocks/coffeenet/autoconfigure/security/CoffeeNetProfileAutoConfigurationTests.java
+++ b/coffeenet-autoconfigure/src/test/java/rocks/coffeenet/autoconfigure/security/CoffeeNetProfileAutoConfigurationTests.java
@@ -4,10 +4,15 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.security.reactive.ReactiveSecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.reactive.ReactiveUserDetailsServiceAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
+import org.springframework.boot.test.context.runner.ReactiveWebApplicationContextRunner;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
 
 import rocks.coffeenet.autoconfigure.security.CoffeeNetProfileAutoConfiguration.CoffeeNetProfileArgumentResolverConfigurer;
+import rocks.coffeenet.autoconfigure.security.reactive.ReactiveCoffeeNetProfileArgumentResolver;
 
 import rocks.coffeenet.platform.domain.profile.DelegatingPrincipalCoffeeNetProfileMapper;
 
@@ -46,17 +51,34 @@ class CoffeeNetProfileAutoConfigurationTests {
 
 
     @Test
-    @DisplayName("should configure a handler method argument resolver for profiles")
+    @DisplayName("should configure a handler method argument resolver for profiles (servlet)")
     void webappContext() {
 
         WebApplicationContextRunner runner = new WebApplicationContextRunner()
                 .withConfiguration(AutoConfigurations.of(SecurityAutoConfiguration.class,
-                            CoffeeNetProfileAutoConfiguration.class))
+                            UserDetailsServiceAutoConfiguration.class, CoffeeNetProfileAutoConfiguration.class))
                 .withUserConfiguration(ProfileMapperTestConfiguration.class);
 
         runner.run(context -> {
             assertThat(context).hasSingleBean(DelegatingPrincipalCoffeeNetProfileMapper.class);
             assertThat(context).hasSingleBean(CoffeeNetProfileArgumentResolverConfigurer.class);
+        });
+    }
+
+
+    @Test
+    @DisplayName("should configure a handler method argument resolver for profiles (reactive)")
+    void reactiveWebappContext() {
+
+        ReactiveWebApplicationContextRunner runner = new ReactiveWebApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(ReactiveSecurityAutoConfiguration.class,
+                            ReactiveUserDetailsServiceAutoConfiguration.class,
+                            CoffeeNetProfileAutoConfiguration.class))
+                .withUserConfiguration(ProfileMapperTestConfiguration.class);
+
+        runner.run(context -> {
+            assertThat(context).hasSingleBean(DelegatingPrincipalCoffeeNetProfileMapper.class);
+            assertThat(context).hasSingleBean(ReactiveCoffeeNetProfileArgumentResolver.class);
         });
     }
 }

--- a/coffeenet-autoconfigure/src/test/java/rocks/coffeenet/autoconfigure/security/ProfileMapperTestConfiguration.java
+++ b/coffeenet-autoconfigure/src/test/java/rocks/coffeenet/autoconfigure/security/ProfileMapperTestConfiguration.java
@@ -1,4 +1,4 @@
-package rocks.coffeenet.autoconfigure.security.servlet;
+package rocks.coffeenet.autoconfigure.security;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -13,10 +13,10 @@ import rocks.coffeenet.platform.domain.profile.PrincipalCoffeeNetProfileMapper;
  * @author  Florian 'punycode' Krupicka - zh@punyco.de
  */
 @Configuration
-class ProfileMapperTestConfiguration {
+public class ProfileMapperTestConfiguration {
 
     @Bean
-    PrincipalCoffeeNetProfileMapper testMapper() {
+    public PrincipalCoffeeNetProfileMapper testMapper() {
 
         return p -> CoffeeNetProfile.withUniqueIdentifierAndName("id", p.getName()).build();
     }

--- a/coffeenet-autoconfigure/src/test/java/rocks/coffeenet/autoconfigure/security/oauth2/OAuth2TextFixtures.java
+++ b/coffeenet-autoconfigure/src/test/java/rocks/coffeenet/autoconfigure/security/oauth2/OAuth2TextFixtures.java
@@ -1,0 +1,12 @@
+package rocks.coffeenet.autoconfigure.security.oauth2;
+
+/**
+ * @author  Florian 'punycode' Krupicka - zh@punyco.de
+ */
+public interface OAuth2TextFixtures {
+
+    String[] OAUTH_GITHUB_PROPERTIES = new String[] {
+        "spring.security.oauth2.client.registration.github.client-id=example-client-id",
+        "spring.security.oauth2.client.registration.github.client-secret=example-client-secret"
+    };
+}

--- a/coffeenet-autoconfigure/src/test/java/rocks/coffeenet/autoconfigure/security/oauth2/reactive/ReactiveOAuth2SecurityCustomizerTests.java
+++ b/coffeenet-autoconfigure/src/test/java/rocks/coffeenet/autoconfigure/security/oauth2/reactive/ReactiveOAuth2SecurityCustomizerTests.java
@@ -1,0 +1,90 @@
+package rocks.coffeenet.autoconfigure.security.oauth2.reactive;
+
+import org.assertj.core.api.Condition;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.security.oauth2.client.reactive.ReactiveOAuth2ClientAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.oauth2.client.servlet.OAuth2ClientAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.reactive.ReactiveSecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.reactive.ReactiveUserDetailsServiceAutoConfiguration;
+import org.springframework.boot.test.context.runner.ReactiveWebApplicationContextRunner;
+
+import org.springframework.security.oauth2.client.web.server.OAuth2AuthorizationRequestRedirectWebFilter;
+import org.springframework.security.oauth2.client.web.server.authentication.OAuth2LoginAuthenticationWebFilter;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import rocks.coffeenet.autoconfigure.security.CoffeeNetSecurityAutoConfiguration;
+
+import rocks.coffeenet.test.app.reactive.ReactiveTestWebApplication;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+/**
+ * @author  Florian 'punycode' Krupicka - zh@punyco.de
+ */
+@DisplayName("ReactiveOAuth2SecurityCustomizer")
+class ReactiveOAuth2SecurityCustomizerTests {
+
+    private ReactiveWebApplicationContextRunner contextRunner;
+
+    @BeforeEach
+    void setupWebApplicationContext() {
+
+        contextRunner = new ReactiveWebApplicationContextRunner().withConfiguration(AutoConfigurations.of(
+                        OAuth2ClientAutoConfiguration.class, ReactiveSecurityAutoConfiguration.class,
+                        ReactiveUserDetailsServiceAutoConfiguration.class, ReactiveOAuth2ClientAutoConfiguration.class,
+                        CoffeeNetSecurityAutoConfiguration.class, ReactiveOAuth2SecurityAutoConfiguration.class))
+                .withUserConfiguration(ReactiveTestWebApplication.class);
+    }
+
+
+    @Test
+    @DisplayName("should enable OAuth2 security on the filter chain if OAuth2 clients registered")
+    void withRegisteredOAuth2Clients() {
+
+        //J-
+        //@formatter:off
+        contextRunner.withPropertyValues(
+            "spring.security.oauth2.client.registration.github.client-id=example-client-id",
+            "spring.security.oauth2.client.registration.github.client-secret=example-client-secret")
+            .run(context ->
+                assertThat(context)
+                    .getBean(SecurityWebFilterChain.class)
+                    .extracting(SecurityWebFilterChain::getWebFilters)
+                    .extracting(Flux::collectList)
+                    .extracting(Mono::block)
+                    .asList()
+                    .haveAtLeastOne(new Condition<>(OAuth2LoginAuthenticationWebFilter.class::isInstance, "OAuth2LoginAuthenticationWebFilter"))
+                    .haveAtLeastOne(new Condition<>(OAuth2AuthorizationRequestRedirectWebFilter.class::isInstance, "OAuth2AuthorizationRequestRedirectWebFilter")));
+        //@formatter:on
+        //J+
+    }
+
+
+    @Test
+    @DisplayName("should not enable OAuth2 security on the filter chain if OAuth2 no clients registered")
+    void withoutRegisteredOAuth2Clients() {
+
+        //J-
+        //@formatter:off
+        contextRunner.run(context ->
+            assertThat(context)
+                .getBean(SecurityWebFilterChain.class)
+                .extracting(SecurityWebFilterChain::getWebFilters)
+                .extracting(Flux::collectList)
+                .extracting(Mono::block)
+                .asList()
+                .doesNotHave(new Condition<>(OAuth2LoginAuthenticationWebFilter.class::isInstance, "OAuth2LoginAuthenticationWebFilter"))
+                .doesNotHave(new Condition<>(OAuth2AuthorizationRequestRedirectWebFilter.class::isInstance, "OAuth2AuthorizationRequestRedirectWebFilter")));
+        //@formatter:on
+        //J+
+    }
+}

--- a/coffeenet-autoconfigure/src/test/java/rocks/coffeenet/autoconfigure/security/oauth2/reactive/ReactiveOAuth2SecurityCustomizerTests.java
+++ b/coffeenet-autoconfigure/src/test/java/rocks/coffeenet/autoconfigure/security/oauth2/reactive/ReactiveOAuth2SecurityCustomizerTests.java
@@ -22,6 +22,7 @@ import reactor.core.publisher.Mono;
 
 import rocks.coffeenet.autoconfigure.security.CoffeeNetSecurityAutoConfiguration;
 
+import rocks.coffeenet.autoconfigure.security.oauth2.OAuth2TextFixtures;
 import rocks.coffeenet.test.app.reactive.ReactiveTestWebApplication;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -52,9 +53,7 @@ class ReactiveOAuth2SecurityCustomizerTests {
 
         //J-
         //@formatter:off
-        contextRunner.withPropertyValues(
-            "spring.security.oauth2.client.registration.github.client-id=example-client-id",
-            "spring.security.oauth2.client.registration.github.client-secret=example-client-secret")
+        contextRunner.withPropertyValues(OAuth2TextFixtures.OAUTH_GITHUB_PROPERTIES)
             .run(context ->
                 assertThat(context)
                     .getBean(SecurityWebFilterChain.class)

--- a/coffeenet-autoconfigure/src/test/java/rocks/coffeenet/autoconfigure/security/oauth2/servlet/OAuth2SecurityConfigurerTests.java
+++ b/coffeenet-autoconfigure/src/test/java/rocks/coffeenet/autoconfigure/security/oauth2/servlet/OAuth2SecurityConfigurerTests.java
@@ -17,6 +17,7 @@ import org.springframework.security.oauth2.client.web.OAuth2LoginAuthenticationF
 import org.springframework.security.web.FilterChainProxy;
 
 import rocks.coffeenet.autoconfigure.security.CoffeeNetSecurityAutoConfiguration;
+import rocks.coffeenet.autoconfigure.security.oauth2.OAuth2TextFixtures;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -46,9 +47,7 @@ class OAuth2SecurityConfigurerTests {
 
         //J-
         //@formatter:off
-        contextRunner.withPropertyValues(
-                "spring.security.oauth2.client.registration.github.client-id=example-client-id",
-                "spring.security.oauth2.client.registration.github.client-secret=example-client-secret")
+        contextRunner.withPropertyValues(OAuth2TextFixtures.OAUTH_GITHUB_PROPERTIES)
             .run(context ->
                     assertThat(context)
                         .getBean(FilterChainProxy.class)

--- a/coffeenet-autoconfigure/src/test/java/rocks/coffeenet/autoconfigure/security/oauth2/servlet/OAuth2SecurityConfigurerTests.java
+++ b/coffeenet-autoconfigure/src/test/java/rocks/coffeenet/autoconfigure/security/oauth2/servlet/OAuth2SecurityConfigurerTests.java
@@ -16,7 +16,7 @@ import org.springframework.security.oauth2.client.web.OAuth2AuthorizationCodeGra
 import org.springframework.security.oauth2.client.web.OAuth2LoginAuthenticationFilter;
 import org.springframework.security.web.FilterChainProxy;
 
-import rocks.coffeenet.autoconfigure.security.servlet.CoffeeNetSecurityAutoConfiguration;
+import rocks.coffeenet.autoconfigure.security.CoffeeNetSecurityAutoConfiguration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/coffeenet-autoconfigure/src/test/java/rocks/coffeenet/autoconfigure/security/reactive/ReactiveCoffeeNetProfileArgumentResolverIT.java
+++ b/coffeenet-autoconfigure/src/test/java/rocks/coffeenet/autoconfigure/security/reactive/ReactiveCoffeeNetProfileArgumentResolverIT.java
@@ -1,0 +1,68 @@
+package rocks.coffeenet.autoconfigure.security.reactive;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
+
+import org.springframework.security.test.context.support.WithMockUser;
+
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+import rocks.coffeenet.autoconfigure.security.CoffeeNetProfileAutoConfiguration;
+import rocks.coffeenet.autoconfigure.security.ProfileMapperTestConfiguration;
+
+import rocks.coffeenet.test.app.reactive.ReactiveTestWebApplication;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+
+/**
+ * @author  Florian 'punycode' Krupicka - zh@punyco.de
+ */
+@WebFluxTest
+@ContextConfiguration(
+    classes = {
+        ProfileMapperTestConfiguration.class, ReactiveTestWebApplication.class, CoffeeNetProfileAutoConfiguration.class
+    }
+)
+@DisplayName("ReactiveCoffeeNetProfileArgumentResolver")
+class ReactiveCoffeeNetProfileArgumentResolverIT {
+
+    @Autowired
+    WebTestClient webTestClient;
+
+    @Test
+    @WithMockUser(value = "example")
+    @DisplayName("should inject a profile into a controller if user is authenticated")
+    void authenticatedUser() throws Exception {
+
+        // FIXME: Find a good way to test this.
+
+        webTestClient.get()
+            .uri("/with-profile")
+            .exchange()
+            .expectStatus().isOk()
+            .expectBody().jsonPath("profile.name", "example");
+    }
+
+
+    @Test
+    @DisplayName("should not inject a profile into a controller if user is not authenticated")
+    void noAuthenticatedUser() throws Exception {
+
+        // FIXME: Find a good way to test this.
+
+        webTestClient.get()
+            .uri("/with-profile")
+            .exchange()
+            .expectStatus().isOk()
+            .expectBody().jsonPath("profile.name", is(nullValue()));
+    }
+}

--- a/coffeenet-autoconfigure/src/test/java/rocks/coffeenet/autoconfigure/security/reactive/ReactiveServerHttpSecurityPostProcessorTests.java
+++ b/coffeenet-autoconfigure/src/test/java/rocks/coffeenet/autoconfigure/security/reactive/ReactiveServerHttpSecurityPostProcessorTests.java
@@ -15,7 +15,10 @@ import org.springframework.security.config.web.server.ServerHttpSecurity;
 
 import rocks.coffeenet.autoconfigure.security.CoffeeNetSecurityAutoConfiguration;
 
+import java.util.Collections;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 
 /**
@@ -44,6 +47,22 @@ class ReactiveServerHttpSecurityPostProcessorTests {
             .run((context) ->
                     assertThat(context).getBean(TestCustomizer.class).isNotNull()
                     .satisfies(customizer -> assertThat(customizer.customized).isTrue()));
+    }
+
+    @Test
+    @DisplayName("should error out on null argument to constructor")
+    void nullArgumentToConstructor() {
+        assertThatThrownBy(() -> new ReactiveServerHttpSecurityPostProcessor(null))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("must not be null");
+    }
+
+    @Test
+    @DisplayName("should error out on null argument to constructor")
+    void emptyArgumentToConstructor() {
+        assertThatThrownBy(() -> new ReactiveServerHttpSecurityPostProcessor(Collections.emptyList()))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("must not be empty");
     }
 
     @Configuration

--- a/coffeenet-autoconfigure/src/test/java/rocks/coffeenet/autoconfigure/security/reactive/ReactiveServerHttpSecurityPostProcessorTests.java
+++ b/coffeenet-autoconfigure/src/test/java/rocks/coffeenet/autoconfigure/security/reactive/ReactiveServerHttpSecurityPostProcessorTests.java
@@ -1,0 +1,60 @@
+package rocks.coffeenet.autoconfigure.security.reactive;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.security.reactive.ReactiveSecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.reactive.ReactiveUserDetailsServiceAutoConfiguration;
+import org.springframework.boot.test.context.runner.ReactiveWebApplicationContextRunner;
+
+import org.springframework.context.annotation.Configuration;
+
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+
+import rocks.coffeenet.autoconfigure.security.CoffeeNetSecurityAutoConfiguration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+/**
+ * @author  Florian 'punycode' Krupicka - zh@punyco.de
+ */
+@DisplayName("ReactiveServerHttpSecurityPostProcessor")
+class ReactiveServerHttpSecurityPostProcessorTests {
+
+    private ReactiveWebApplicationContextRunner contextRunner;
+
+    @BeforeEach
+    void setupWebApplicationContext() {
+
+        contextRunner =
+            new ReactiveWebApplicationContextRunner().withConfiguration(AutoConfigurations.of(
+                    ReactiveSecurityAutoConfiguration.class, ReactiveUserDetailsServiceAutoConfiguration.class,
+                    ReactiveCoffeeNetSecurityAutoConfiguration.class, CoffeeNetSecurityAutoConfiguration.class));
+    }
+
+
+    @Test
+    @DisplayName("should run custom CoffeeNet security customizer when bean present")
+    void customSecurityConfigurer() {
+
+        contextRunner.withUserConfiguration(TestCustomizer.class)
+            .run((context) ->
+                    assertThat(context).getBean(TestCustomizer.class).isNotNull()
+                    .satisfies(customizer -> assertThat(customizer.customized).isTrue()));
+    }
+
+    @Configuration
+    static class TestCustomizer implements ReactiveServerHttpSecurityCustomizer {
+
+        private boolean customized = false;
+
+        @Override
+        public void customize(ServerHttpSecurity http) {
+
+            customized = true;
+        }
+    }
+}

--- a/coffeenet-autoconfigure/src/test/java/rocks/coffeenet/autoconfigure/security/servlet/CoffeeNetProfileArgumentResolverIT.java
+++ b/coffeenet-autoconfigure/src/test/java/rocks/coffeenet/autoconfigure/security/servlet/CoffeeNetProfileArgumentResolverIT.java
@@ -16,9 +16,11 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import org.springframework.web.context.WebApplicationContext;
 
+import rocks.coffeenet.autoconfigure.security.ProfileMapperTestConfiguration;
+
 import rocks.coffeenet.platform.domain.profile.CoffeeNetProfile;
 
-import rocks.coffeenet.test.app.TestWebApplication;
+import rocks.coffeenet.test.app.MvcTestWebApplication;
 
 import static org.hamcrest.Matchers.isA;
 import static org.hamcrest.Matchers.nullValue;
@@ -34,7 +36,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * @author  Florian 'punycode' Krupicka - zh@punyco.de
  */
 @SpringBootTest
-@ContextConfiguration(classes = { ProfileMapperTestConfiguration.class, TestWebApplication.class })
+@ContextConfiguration(classes = { ProfileMapperTestConfiguration.class, MvcTestWebApplication.class })
 @DisplayName("CoffeeNetProfileArgumentResolver")
 class CoffeeNetProfileArgumentResolverIT {
 

--- a/coffeenet-autoconfigure/src/test/java/rocks/coffeenet/autoconfigure/security/servlet/CoffeeNetProfileArgumentResolverIT.java
+++ b/coffeenet-autoconfigure/src/test/java/rocks/coffeenet/autoconfigure/security/servlet/CoffeeNetProfileArgumentResolverIT.java
@@ -18,24 +18,21 @@ import org.springframework.web.context.WebApplicationContext;
 
 import rocks.coffeenet.autoconfigure.security.ProfileMapperTestConfiguration;
 
-import rocks.coffeenet.platform.domain.profile.CoffeeNetProfile;
+import rocks.coffeenet.test.app.servlet.MvcTestWebApplication;
 
-import rocks.coffeenet.test.app.MvcTestWebApplication;
-
-import static org.hamcrest.Matchers.isA;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 
-import static org.springframework.test.web.servlet.ResultMatcher.matchAll;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
 
 /**
  * @author  Florian 'punycode' Krupicka - zh@punyco.de
  */
-@SpringBootTest
+@SpringBootTest(properties = "spring.main.web-application-type=servlet")
 @ContextConfiguration(classes = { ProfileMapperTestConfiguration.class, MvcTestWebApplication.class })
 @DisplayName("CoffeeNetProfileArgumentResolver")
 class CoffeeNetProfileArgumentResolverIT {
@@ -62,15 +59,8 @@ class CoffeeNetProfileArgumentResolverIT {
 
         // FIXME: Find a good way to test this.
 
-        //J-
-        //@formatter:off
         mvc.perform(get("/with-profile"))
-            .andExpect(matchAll(
-                model().attributeExists("profile"),
-                model().attribute("profile", isA(CoffeeNetProfile.class))
-            ));
-        //@formatter:on
-        //J+
+            .andExpect(jsonPath("profile.name", is("example")));
     }
 
 
@@ -80,13 +70,7 @@ class CoffeeNetProfileArgumentResolverIT {
 
         // FIXME: Find a good way to test this.
 
-        //J-
-        //@formatter:off
         mvc.perform(get("/with-profile"))
-            .andExpect(matchAll(
-                model().attribute("profile", nullValue())
-            ));
-        //@formatter:on
-        //J+
+            .andExpect(jsonPath("profile", is(nullValue())));
     }
 }

--- a/coffeenet-autoconfigure/src/test/java/rocks/coffeenet/autoconfigure/security/servlet/DelegatingSecurityConfigurerTests.java
+++ b/coffeenet-autoconfigure/src/test/java/rocks/coffeenet/autoconfigure/security/servlet/DelegatingSecurityConfigurerTests.java
@@ -17,6 +17,8 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 
+import rocks.coffeenet.autoconfigure.security.CoffeeNetSecurityAutoConfiguration;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 

--- a/coffeenet-autoconfigure/src/test/java/rocks/coffeenet/test/app/AbstractTestWebApplication.java
+++ b/coffeenet-autoconfigure/src/test/java/rocks/coffeenet/test/app/AbstractTestWebApplication.java
@@ -1,0 +1,23 @@
+package rocks.coffeenet.test.app;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import rocks.coffeenet.platform.domain.profile.CoffeeNetProfile;
+
+import java.util.Collections;
+import java.util.Map;
+
+
+/**
+ * @author  Florian 'punycode' Krupicka - zh@punyco.de
+ */
+@RestController
+public class AbstractTestWebApplication {
+
+    @GetMapping("/with-profile")
+    public Map<String, Object> withProfile(CoffeeNetProfile profile) {
+
+        return Collections.singletonMap("profile", profile);
+    }
+}

--- a/coffeenet-autoconfigure/src/test/java/rocks/coffeenet/test/app/MvcTestWebApplication.java
+++ b/coffeenet-autoconfigure/src/test/java/rocks/coffeenet/test/app/MvcTestWebApplication.java
@@ -21,7 +21,7 @@ import rocks.coffeenet.platform.domain.profile.CoffeeNetProfile;
  */
 @SpringBootApplication
 @Controller
-public class TestWebApplication {
+public class MvcTestWebApplication {
 
     @GetMapping("/with-profile")
     public String withProfile(Model model, CoffeeNetProfile profile) {

--- a/coffeenet-autoconfigure/src/test/java/rocks/coffeenet/test/app/reactive/ReactiveTestWebApplication.java
+++ b/coffeenet-autoconfigure/src/test/java/rocks/coffeenet/test/app/reactive/ReactiveTestWebApplication.java
@@ -1,0 +1,29 @@
+package rocks.coffeenet.test.app.reactive;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+import org.springframework.context.annotation.Bean;
+
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+
+import org.springframework.web.bind.annotation.RestController;
+
+import rocks.coffeenet.test.app.AbstractTestWebApplication;
+
+
+/**
+ * @author  Florian 'punycode' Krupicka - zh@punyco.de
+ */
+@SpringBootApplication
+@RestController
+public class ReactiveTestWebApplication extends AbstractTestWebApplication {
+
+    @Bean
+    public SecurityWebFilterChain securityWebFilterChain(ServerHttpSecurity http) {
+
+        return http.authorizeExchange()
+            .anyExchange().permitAll()
+            .and().build();
+    }
+}

--- a/coffeenet-autoconfigure/src/test/java/rocks/coffeenet/test/app/servlet/MvcTestWebApplication.java
+++ b/coffeenet-autoconfigure/src/test/java/rocks/coffeenet/test/app/servlet/MvcTestWebApplication.java
@@ -1,4 +1,4 @@
-package rocks.coffeenet.test.app;
+package rocks.coffeenet.test.app.servlet;
 
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
@@ -7,29 +7,17 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 
-import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RestController;
 
-import org.springframework.ui.Model;
-
-import org.springframework.web.bind.annotation.GetMapping;
-
-import rocks.coffeenet.platform.domain.profile.CoffeeNetProfile;
+import rocks.coffeenet.test.app.AbstractTestWebApplication;
 
 
 /**
  * @author  Florian 'punycode' Krupicka - zh@punyco.de
  */
 @SpringBootApplication
-@Controller
-public class MvcTestWebApplication {
-
-    @GetMapping("/with-profile")
-    public String withProfile(Model model, CoffeeNetProfile profile) {
-
-        model.addAttribute("profile", profile);
-
-        return "result";
-    }
+@RestController
+public class MvcTestWebApplication extends AbstractTestWebApplication {
 
     @Configuration
     public class SecurityConfig extends WebSecurityConfigurerAdapter {


### PR DESCRIPTION
Add auto-configuration for WebFlux based applications in the same manner, that servlet based applications are instrumented. Specifically add auto-configuration for OAuth2 authentication on all WebFlux `ServerHttpSecurity` instances and the method argument resolution of `CoffeeNetProfile` for those applications.
