### PR TITLE
Update build JDK to 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,10 @@ jobs:
         git fetch --no-tags --prune origin \
           +refs/heads/${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}
       if: github.event_name == 'pull_request'
-    - name: Set up JDK 1.8
+    - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 11
     - name: Verify Gradle Wrapper version
       uses: gradle/wrapper-validation-action@v1
     - name: Recreate Gradle wrapper cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,10 +18,10 @@ jobs:
       run: |
         git fetch --no-tags --prune origin +refs/heads/master:refs/remotes/origin/master
         git merge-base --is-ancestor ${{ github.ref }} refs/remotes/origin/master
-    - name: Set up JDK 1.8
+    - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 11
     - name: Verify Gradle Wrapper version
       uses: gradle/wrapper-validation-action@v1
     - name: Recreate Gradle wrapper cache


### PR DESCRIPTION
Since SonarQube now doesn't support JDK 1.8 anymore, we will build with
JDK11 instead. This should not impact the use of CoffeeNet with JDK 1.8,
since this is still the compile target.