### PR TITLE
Fix: multiple warnings and errors with new Gradle version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
       # Run only if current version is actually a development version
       run: |
         if ./scripts/is_development; then
-          ./gradlew -Psonatype build publishToSonatype
+          ./gradlew -Psonatype -PsignGpg build publishToSonatype
         fi
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Publish artifacts to Sonatype OSSRH
       run: |
-        ./gradlew -Psonatype build publishToSonatype closeAndReleaseRepository
+        ./gradlew -Psonatype -PsignGpg build publishToSonatype closeAndReleaseSonatypeStagingRepository
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,21 @@
 plugins {
     id "org.sonarqube" version "2.8"
+    id "io.github.gradle-nexus.publish-plugin" version "1.1.0"
 }
 
 description = "CoffeeNet Boot Build"
+
+// Configure Sonatype OSS publishing if requested
+if (project.hasProperty("sonatype")) {
+    nexusPublishing {
+        repositories {
+            sonatype {
+                username = providers.environmentVariable("SONATYPE_USERNAME")
+                password = providers.environmentVariable("SONATYPE_PASSWORD")
+            }
+        }
+    }
+}
 
 allprojects {
     group "rocks.coffeenet"

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -30,10 +30,6 @@ gradlePlugin {
 }
 
 dependencies {
-    // Support publishing to Sonatype OSS repository
-    implementation 'de.marcphilipp.gradle:nexus-publish-plugin:0.4.0'
-    implementation 'io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.21.2'
-
     // Tests
     testImplementation gradleTestKit()
     testImplementation 'org.assertj:assertj-core:3.13.2'

--- a/buildSrc/src/main/java/rocks/coffeenet/build/CoveragePlugin.java
+++ b/buildSrc/src/main/java/rocks/coffeenet/build/CoveragePlugin.java
@@ -36,8 +36,8 @@ public class CoveragePlugin implements Plugin<Project> {
 
             project.getTasks().withType(JacocoReport.class).all((jacoco) -> {
                 jacoco.reports((report) -> {
-                    report.getXml().setEnabled(true);
-                    report.getHtml().setEnabled(false);
+                    report.getXml().getRequired().set(true);
+                    report.getHtml().getRequired().set(false);
                 });
                 project.getTasks().withType(Test.class).all((test) -> jacoco.dependsOn(test));
                 checkTaskName.dependsOn(jacoco);


### PR DESCRIPTION
With upgrade to Gradle 7.1.1 the publishing tasks were having problems with evaluation order.

This simplifies the `DeployedPlugin` and moves the Nexus publishing to a [new plugin](https://github.com/gradle-nexus/publish-plugin) that is only applied at the top-level project only.